### PR TITLE
Make 'npm test' command work for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ This is convenient during development to separate concerns.
 
 You should pass an array of apis as first parameter of the middleware. api objects must respect the following structure.
 
-Property | Required | Type | Description
-----------|--------|---------------|-------------
-`pattern` | yes | String | A pattern that `request.url` property should match to be mocked. It will be passed as RegExp argument.
-`enabled` | no | Boolean | A boolean that determine if the middleware should handle this `api`.
-`headers` | no | Array of Objects | A array of objects ({key: '', value: ''}) that represents HTTP headers of the mocked `response`.
-`status` | no | Number | A number that will be the `HTTP status` of the mocked `response`.
-`body` | no | Function | A function that take as parameter the `request` object and should return a string that will be the `message-body` of the mocked `response`.
+Property  | Required | Type             | Default value | Description
+----------|----------|------------------|---------------|-------------
+`pattern` | yes      | String           | none          | A pattern that `request.url` property should match to be mocked. It will be passed as RegExp argument.
+`enabled` | no       | Boolean          | `true`        | A boolean that determine if the middleware should handle this `api`.
+`headers` | no       | Array of Objects | `[]`          | A array of objects ({key: '', value: ''}) that represents HTTP headers of the mocked `response`.
+`status`  | no       | Number           | `200`         | A number that will be the `HTTP status` of the mocked `response`.
+`body`    | no       | Function         | `() => ''`    | A function that take as parameter the `request` object and should return a string that will be the `message-body` of the mocked `response`.
 
 You can also add an optional configuration object as second parameter.
 
-Parameter | Required | Default value | Description
-----------|--------|---------------|-------------
-`enabled` | no | `true` | A boolean that determine if the middleware is `enabled` or not.
-`force` | no | `false` | Set to true it tells the middleware to ignore `enabled` property of `apis` objects.
-`logger` | no | `empty function` | Pass your own logger function that takes a string as parameter.
+Parameter | Required | Type             | Default value | Description
+----------|----------|------------------|---------------|-------------
+`enabled` | no       | Boolean          | `true`        | A boolean that determine if the middleware is `enabled` or not.
+`force`   | no       | Boolean          | `false`       | Set to true it tells the middleware to ignore `enabled` property of `apis` objects.
+`logger`  | no       | Function         | `() => {}`    | Pass your own logger function that takes a string as parameter.
 
 The middleware call `next` function of `express` when no pattern is matched. Otherwise the `response` is instantly sent to client.
 
@@ -43,7 +43,7 @@ HTTP requests should be proxified otherwise the middleware won't work.
 For it you could use `http-proxy-middleware`.
 
 **server.js**
-```(javascript)
+```javascript
 import express from 'express'
 import proxy from 'http-proxy-middleware'
 import mockups from 'express-mockups-middleware'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "lint": "eslint src/index.js",
     "build": "cross-env BABEL_ENV=cjs babel --ignore \"*.spec.js\" ./src/ --out-dir build",
-    "test": "NODE_ENV=test mocha --recursive --compilers js:babel-register --require ./misc/testSetup.js \"src/**/*.spec.js\" "
+    "test": "cross-env NODE_ENV=test mocha --recursive --compilers js:babel-register --require ./misc/testSetup.js \"src/**/*.spec.js\" "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm test` command was not working on windows, due to the "NODE_ENV is not recognized as an internal or external command" error.

This PR fixes the issue by using cross-env in the test script.