### PR TITLE
Make 'npm test' command work for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "lint": "eslint src/index.js",
     "build": "cross-env BABEL_ENV=cjs babel --ignore \"*.spec.js\" ./src/ --out-dir build",
-    "test": "NODE_ENV=test mocha --recursive --compilers js:babel-register --require ./misc/testSetup.js \"src/**/*.spec.js\" "
+    "test": "cross-env NODE_ENV=test mocha --recursive --compilers js:babel-register --require ./misc/testSetup.js \"src/**/*.spec.js\" "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm test command was not working on windows, due to the "NODE_ENV is not recognized as an internal or external command" error.

This PR fixes the issue by using cross-env in the test script.